### PR TITLE
Fix start param issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function search(options, callback) {
   if(options.age) params.tbs = 'qdr:' + options.age;
   if(options.query) params.q = options.query;
 
-  params.start = 0;
+  params.start = params.start || 0;
 
   getPage(params, function onPage(err, body) {
     if(err) {


### PR DESCRIPTION
If you tried:
```javascript
var options = {
    query: 'site:https://play.google.com/store/ "@gmail.com"',
    host: 'www.google.com',
    lang: 'en',
    limit: 10,
    params: {
        start: 31
    }
};
```
the `start` parameter would be ignored. This pull request solves that.