### PR TITLE
Enhancement to return title, desc & metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,14 +96,13 @@ function search(options, callback) {
       var item = {};
 
       var elemUrl = $(this).find("h3 a");
-      var parsedUrl = url.parse(elemUrl[0].attribs.href, true);
       var elemMeta = $(this).find(".slp");
       var elemDesc = $(this).find(".st");
-
+      var parsedUrl = url.parse(elemUrl.attr("href"), true);
       if (parsedUrl.pathname === '/url') {
         item['url'] = parsedUrl.query.q;
       }
-      item['title'] = elemUrl[0].children[0].data;
+      item['title'] = elemUrl.text();
       item['meta'] = elemMeta.text();
       item['desc'] = elemDesc.text();
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function search(options, callback) {
     });
 
     newResults.forEach(function(result) {
-      callback(null, result);
+      callback(null, result['url'], result);
     });
 
     if(newResults.length === 0) {
@@ -92,12 +92,23 @@ function search(options, callback) {
     var results = [];
     var $ = cheerio.load(body);
 
-    $('.g h3 a').each(function(i, elem) {
-      var parsed = url.parse(elem.attribs.href, true);
-      if (parsed.pathname === '/url') {
-        results.push(parsed.query.q);
+    $('.g').each(function(i, elem) {
+      var item = {};
+
+      var elemUrl = $(this).find("h3 a");
+      var parsedUrl = url.parse(elemUrl[0].attribs.href, true);
+      var elemMeta = $(this).find(".slp");
+      var elemDesc = $(this).find(".st");
+
+      if (parsedUrl.pathname === '/url') {
+        item['url'] = parsedUrl.query.q;
       }
-    });
+      item['title'] = elemUrl[0].children[0].data;
+      item['meta'] = elemMeta.text();
+      item['desc'] = elemDesc.text();
+
+      results.push(item);
+    });    
 
     return results;
   }

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function search(options, callback) {
     var results = [];
     var $ = cheerio.load(body);
 
-    $('.g').each(function(i, elem) {
+    $('#search .g').each(function(i, elem) {
       var item = {};
 
       var elemUrl = $(this).find("h3 a");


### PR DESCRIPTION
Add capability to retrieve title, descriptions & metadata (if any) as mentioned in #1 . Backward compatible.

```
var scraper = require('google-search-scraper');

var options = {
  query: 'nodejs',
  limit: 10
};

scraper.search(options, function(err, url, meta) {
  // This is called for each result
  if(err) throw err;
  console.log(url);
  console.log(meta.title);
  console.log(meta.meta);
  console.log(meta.desc)
});